### PR TITLE
Prevents tandy docs link from 404ing

### DIFF
--- a/lib/content/packages.js
+++ b/lib/content/packages.js
@@ -41,6 +41,7 @@ module.exports = {
     },
     tandy: {
         subtitle: 'Auto-generated, RESTful, CRUDdy route handlers for Objection models',
+        ref: 'master', // Only show master; doesn't tag releases
         apisBegin: null
     },
     hodgepodge: {


### PR DESCRIPTION
The tandy docs are unavailable on production, following their link shows a 404. This tweak — also included in #36 , but extracted here in case pushing up quickly is of interest — should fix that, pins their docs URL to the repo's `master` branch.